### PR TITLE
Phone number validation

### DIFF
--- a/frontend/components/BookingForm/__snapshots__/Booking.integration.test.tsx.snap
+++ b/frontend/components/BookingForm/__snapshots__/Booking.integration.test.tsx.snap
@@ -2314,8 +2314,9 @@ exports[`Booking Form Step 3 matches its snapshot 1`] = `
               <input
                 data-testid="phone"
                 name="phone"
+                pattern="[+]?[0-9]{6,}"
                 required=""
-                type="text"
+                type="tel"
                 value=""
               />
             </div>

--- a/frontend/components/BookingForm/steps/Details/index.tsx
+++ b/frontend/components/BookingForm/steps/Details/index.tsx
@@ -32,7 +32,7 @@ const Details: StepComponent = () => {
           <Field label="First Name" name="firstName" required />
           <Field label="Last Name" name="lastName" required />
           <Field label="Email" name="email" type="email" required />
-          <Field label="Phone" name="phone" required />
+          <Field label="Phone" name="phone" type="tel" pattern="[+]?[0-9]{6,}" required />
           <Field label="Rego (Optional)" name="rego" />
           <Field label="Company (Optional)" name="company" />
           <CustomButton type={ButtonType.submit} iconLeft={false} icon={<Done />} onClick={() => null}>

--- a/frontend/components/Field/index.tsx
+++ b/frontend/components/Field/index.tsx
@@ -9,9 +9,10 @@ interface Props {
   type?: string;
   value?: string;
   disabled?: boolean;
+  pattern?: string;
 }
 
-const Field = ({ name, label, required = false, type = 'text', value, disabled = false }: Props) => {
+const Field = ({ name, label, required = false, type = 'text', value, disabled = false, pattern }: Props) => {
   const { errors, touched, values } = useFormikContext<Record<string, unknown>>();
   const invalid = useMemo(() => errors[name] && touched[name], [errors, touched]);
 
@@ -28,6 +29,7 @@ const Field = ({ name, label, required = false, type = 'text', value, disabled =
         required={required}
         data-testid={name}
         disabled={disabled}
+        pattern={pattern}
       />
     </div>
   );


### PR DESCRIPTION
Adds a pattern attribute to force phone numbers of at least 6 digits and with an optional '+' character at the start.

Fixes #110 