### PR TITLE
Feature/password reset

### DIFF
--- a/app/authentication/urls.py
+++ b/app/authentication/urls.py
@@ -5,10 +5,11 @@ from .views import LogoutView, user_detail, users_list
 authentication_urls = [
     path('login/', auth_views.LoginView.as_view(template_name="login.html"), name="login"),
     path('logout/', LogoutView, name="logout"),
-    path('password_reset/', auth_views.PasswordResetView.as_view(template_name="reset/reset.html", email_template_name="reset/email.html",
-                                                                 subject_template_name="reset/subject.txt", success_url="/login"), name="reset"),
-    path('password_reset_confirm/<str:uidb64>/<str:token>', auth_views.PasswordResetConfirmView.as_view(template_name="reset/reset_confirm.html", success_url="/login"),
-         name="reset_confirm")
+    path('password_reset/', auth_views.PasswordResetView.as_view(template_name="reset/reset.html",
+                                                                 email_template_name="reset/email.html", subject_template_name="reset/subject.txt", success_url="/login"),
+         name="reset"),
+    path('password_reset_confirm/<str:uidb64>/<str:token>', auth_views.PasswordResetConfirmView.as_view(
+        template_name="reset/reset_confirm.html", success_url="/login"), name="reset_confirm")
 ]
 
 api_urls = [

--- a/app/authentication/urls.py
+++ b/app/authentication/urls.py
@@ -5,10 +5,10 @@ from .views import LogoutView, user_detail, users_list
 authentication_urls = [
     path('login/', auth_views.LoginView.as_view(template_name="login.html"), name="login"),
     path('logout/', LogoutView, name="logout"),
-    path('password_reset/', auth_views.PasswordResetView.as_view(template_name="reset/reset.html", email_template_name="reset/email.html", 
-    subject_template_name="reset/subject.txt", success_url="/login"), name="reset"),
-    path('password_reset_confirm/<str:uidb64>/<str:token>', auth_views.PasswordResetConfirmView.as_view(template_name="reset/reset_confirm.html", success_url="/login"), 
-    name="reset_confirm")
+    path('password_reset/', auth_views.PasswordResetView.as_view(template_name="reset/reset.html", email_template_name="reset/email.html",
+                                                                 subject_template_name="reset/subject.txt", success_url="/login"), name="reset"),
+    path('password_reset_confirm/<str:uidb64>/<str:token>', auth_views.PasswordResetConfirmView.as_view(template_name="reset/reset_confirm.html", success_url="/login"),
+         name="reset_confirm")
 ]
 
 api_urls = [

--- a/app/authentication/urls.py
+++ b/app/authentication/urls.py
@@ -5,6 +5,10 @@ from .views import LogoutView, user_detail, users_list
 authentication_urls = [
     path('login/', auth_views.LoginView.as_view(template_name="login.html"), name="login"),
     path('logout/', LogoutView, name="logout"),
+    path('password_reset/', auth_views.PasswordResetView.as_view(template_name="reset/reset.html", email_template_name="reset/email.html", 
+    subject_template_name="reset/subject.txt", success_url="/login"), name="reset"),
+    path('password_reset_confirm/<str:uidb64>/<str:token>', auth_views.PasswordResetConfirmView.as_view(template_name="reset/reset_confirm.html", success_url="/login"), 
+    name="reset_confirm")
 ]
 
 api_urls = [

--- a/app/authentication/urls.py
+++ b/app/authentication/urls.py
@@ -6,7 +6,7 @@ authentication_urls = [
     path('login/', auth_views.LoginView.as_view(template_name="login.html"), name="login"),
     path('logout/', LogoutView, name="logout"),
     path('password_reset/', auth_views.PasswordResetView.as_view(template_name="reset/reset.html",
-                                                                 email_template_name="reset/email.html", subject_template_name="reset/subject.txt", success_url="/login"),
+         email_template_name="reset/email.html", subject_template_name="reset/subject.txt", success_url="/login"),
          name="reset"),
     path('password_reset_confirm/<str:uidb64>/<str:token>', auth_views.PasswordResetConfirmView.as_view(
         template_name="reset/reset_confirm.html", success_url="/login"), name="reset_confirm")

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -94,7 +94,7 @@ LOGIN_URL = "login/"
 LOGIN_REDIRECT_URL = "/"  # in case next parameter is not specified in GET request
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 # EMAIL_HOST =
-#EMAIL_PORT = 25
+# EMAIL_PORT = 25
 # EMAIL_HOST_USER =
 # EMAIL_HOST_PASSWORD =
 

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -93,10 +93,10 @@ AUTH_USER_MODEL = 'authentication.User'
 LOGIN_URL = "login/"
 LOGIN_REDIRECT_URL = "/"  # in case next parameter is not specified in GET request
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-#EMAIL_HOST = 
+# EMAIL_HOST =
 #EMAIL_PORT = 25
-#EMAIL_HOST_USER = 
-#EMAIL_HOST_PASSWORD = 
+# EMAIL_HOST_USER =
+# EMAIL_HOST_PASSWORD =
 
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -92,6 +92,11 @@ AUTH_PASSWORD_VALIDATORS = [
 AUTH_USER_MODEL = 'authentication.User'
 LOGIN_URL = "login/"
 LOGIN_REDIRECT_URL = "/"  # in case next parameter is not specified in GET request
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+#EMAIL_HOST = 
+#EMAIL_PORT = 25
+#EMAIL_HOST_USER = 
+#EMAIL_HOST_PASSWORD = 
 
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'

--- a/app/resources/static/styles/admin_form.css
+++ b/app/resources/static/styles/admin_form.css
@@ -39,3 +39,8 @@
   border: 3px solid var(--uwa-blue);
   resize: vertical;
 }
+
+.error {
+  color: var(--uwa-secondary-red);
+  margin-bottom: 24px;
+}

--- a/app/resources/static/styles/login.css
+++ b/app/resources/static/styles/login.css
@@ -40,3 +40,14 @@
   margin-bottom: 24px;
 }
 
+.reset {
+  height: 100%;
+  width: 100%;
+  max-width: 100%;
+  max-height: 100%;
+  background-color: var(--white);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}

--- a/app/resources/templates/admin.html
+++ b/app/resources/templates/admin.html
@@ -14,7 +14,7 @@
       <div class="sidebar">
           <a href="/admin" class="h4-thin white {% if request.path == "/admin/" %}active{% endif %}">Dashboard</a>
           <a href="/admin/carparks" class="h4-thin white {% if "carparks" in request.path %}active{% endif %}">Car parks</a>
-          <a href="/admin/bookings" class="h4-thin white">Bookings</a>
+          <a href="/admin/bookings" class="h4-thin white {% if "bookings" in request.path %}active{% endif %}">Bookings</a>
           <a href="/admin/users" class="h4-thin white {% if "users" in request.path %}active{% endif %}">Users</a>
           <a href="/admin/settings" class="h4-thin white {% if "settings" in request.path %}active{% endif %}">Settings</a>
           <a href="/logout" class="h4-thin white">Logout</a>

--- a/app/resources/templates/login.html
+++ b/app/resources/templates/login.html
@@ -41,6 +41,7 @@
             <p>Remember Me</p>
             <button type="submit" value="login" class="login-btn p-bold">Login</button>
           </div>
+          <a href="/password_reset"> Forgot password? </a>
       </form>
     </div>
   </div>

--- a/app/resources/templates/password.html
+++ b/app/resources/templates/password.html
@@ -20,7 +20,9 @@
       </div>
 
       {% csrf_token %}
-      {{ form.errors }}
+      <div class="error">
+      {{ form.password2.errors }}
+      </div>
 
       <div class="admin-form-field">
         {{form.password1.label_tag}}
@@ -32,7 +34,6 @@
         {{form.password2.label_tag}}
         {{form.password2}}
       </div>
-      {{form.password2.help_text}}
     </form>
   </div>
 {% endblock %}

--- a/app/resources/templates/reset/email.html
+++ b/app/resources/templates/reset/email.html
@@ -1,0 +1,4 @@
+Someone requested a password reset for the UniPark Booking System account associated with email {{ email }}. Follow the link below:
+{{ protocol}}://{{ domain }}{% url 'reset_confirm' uidb64=uid token=token %}
+
+If this is not you, please contact UniPark.

--- a/app/resources/templates/reset/reset.html
+++ b/app/resources/templates/reset/reset.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block head_content %}
+    {% load static %}
+    <link rel="stylesheet" type="text/css" href="{% static 'styles/login.css' %}">
+    <link rel="stylesheet" type="text/css" href="{% static '/styles/home.css' %}">
+{% endblock %}
+{% block title %} UniPark | Reset Password {% endblock %}    
+
+{% block content %}
+    <div class="home-wrapper">
+        <div class="reset">
+            <p> Please enter the email associated with the account. A one-time
+            link will be sent to the email allowing you to reset your password. </p> 
+            <br> <br>
+            <form method="POST" class="login-form"> 
+              {% csrf_token %}
+              <div class="field"> 
+                {{ form.email.label_tag }}
+                {{ form.email }} 
+              </div>
+              <div class="login-submit">
+                <button type="submit" class="login-btn p-bold"> Send </button>
+              </div>
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/app/resources/templates/reset/reset_confirm.html
+++ b/app/resources/templates/reset/reset_confirm.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block head_content %}
+    {% load static %}
+    <link rel="stylesheet" type="text/css" href="{% static 'styles/login.css' %}">
+    <link rel="stylesheet" type="text/css" href="{% static '/styles/home.css' %}">
+{% endblock %}
+{% block title %} UniPark | Reset Password Confirmation {% endblock %}    
+
+{% block content %}
+    <div class="home-wrapper">
+        <div class="reset">
+            <p> Please enter a new password </p> 
+            <br> <br>
+            <form method="POST" class="login-form"> 
+              {% csrf_token %}
+              {{ form.new_password1.help_text }}
+              <br>
+              <div class="field"> 
+                {{ form.new_password1.label_tag }}
+                {{ form.new_password1 }} 
+              </div>
+              <div class="field"> 
+                {{ form.new_password2.label_tag }}
+                {{ form.new_password2 }} 
+              </div>
+              <div class="login-submit">
+                <button type="submit" class="login-btn p-bold"> Submit </button>
+              </div>
+              <div class="error"> 
+                {{ form.new_password2.errors }}
+              </div>
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/app/resources/templates/reset/subject.txt
+++ b/app/resources/templates/reset/subject.txt
@@ -1,0 +1,1 @@
+UniPark Reset Password Link


### PR DESCRIPTION
Closes #73 

![image](https://user-images.githubusercontent.com/50038558/136380130-60638528-8673-49c2-80c7-e33f6893373c.png)

![image](https://user-images.githubusercontent.com/50038558/136380198-24370422-ba28-46a5-8d19-21293c3790c9.png)


## Proposed Changes
  - Implements password reset feature
  - Currently EMAIL.BACKEND in settings.py has been set to django.core.mail.backends.console.EmailBackend. This field can be changed to django.core.mail.backends.smtp.EmailBackend on the server (and other fields commented out below it should be set too)
  - I have also included 2 improvements/fixes:
      > fixed the Bookings tab of the Admin Panel not having the white left-border
      > Password change form shows validation errors in red