### PR TITLE
added dashboard page

### DIFF
--- a/app/admin/views.py
+++ b/app/admin/views.py
@@ -18,7 +18,7 @@ from .utils import common_decorators, renderPDF
 @login_required(login_url="/login")
 @staff_member_required(login_url="/admin/staff_required")
 def AdminView(request):
-    return render(request, "admin.html")
+    return render(request, "dashboard.html")
 
 @login_required(login_url="/login")
 def StaffRequiredView(request):

--- a/app/resources/static/styles/dashboard.css
+++ b/app/resources/static/styles/dashboard.css
@@ -1,0 +1,9 @@
+@font-face {
+    font-family: 'Alegreya';
+    src: url('')
+}
+
+.dashboard {
+    padding: 50px;
+    font-size: 24px;
+}

--- a/app/resources/static/styles/dashboard.css
+++ b/app/resources/static/styles/dashboard.css
@@ -1,9 +1,0 @@
-@font-face {
-    font-family: 'Alegreya';
-    src: url('')
-}
-
-.dashboard {
-    padding: 50px;
-    font-size: 24px;
-}

--- a/app/resources/templates/dashboard.html
+++ b/app/resources/templates/dashboard.html
@@ -1,0 +1,25 @@
+{% extends 'admin.html' %}
+
+{% block admin_head %}
+    {% load static %}
+    <link rel="stylesheet" type="text/css" href="{% static '/styles/dashboard.css' %}">
+{% endblock %}
+
+{% block admin_content %}
+    <div class="dashboard">
+        Welcome to the Admin Panel! <br />
+        <ul>
+            <li> 
+                Documentation for the Admin Panel can be found <a href="https://drive.google.com/file/d/1_8X9ecMo2S6YUvN0GXyE2AWd-r5-_dEB/view?usp=sharing" 
+                target="_blank" rel="noopener noreferrer"> here</a>. 
+            </li> 
+            <li>
+                Documentation for the booking process (user manual) can be found <a href="https://drive.google.com/file/d/1xEMgkj7YqwY5IHF_m3EFmJSTwVdlgu1x/view?usp=sharing" target="_blank" 
+                rel="noopener noreferrer"> here</a>.
+            </li>
+        </ul>
+
+        This website was developed by Dylan Kennedy, Jayden Teo, Arun Muthu, Joel Milligan, Pin-Hsuan Tseng and 
+        Joel Fitzpatrick as part of the CITS3200 unit.
+    </div>
+{% endblock %}

--- a/app/resources/templates/dashboard.html
+++ b/app/resources/templates/dashboard.html
@@ -1,8 +1,12 @@
 {% extends 'admin.html' %}
 
 {% block admin_head %}
-    {% load static %}
-    <link rel="stylesheet" type="text/css" href="{% static '/styles/dashboard.css' %}">
+    <style>
+        .dashboard {
+            padding: 50px;
+            font-size: 23px;
+        }
+    </style>
 {% endblock %}
 
 {% block admin_content %}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/50038558/137180013-e897a4bd-5258-45a1-aa16-8681fa6db670.png)

Closes #48 

## Proposed Changes
  - Very plain dashboard page
  - Contains links to admin and user manual PDFs hosted on Google Drive for free