### PR TITLE
Polished Booking, added 100% coverage

### DIFF
--- a/app/admin/views.py
+++ b/app/admin/views.py
@@ -113,7 +113,7 @@ def BayEdit(request, pk, pk2):
 @common_decorators(['GET'])
 def BookingsView(request):
     if (request.method == 'GET'):
-        bookings = Bookings.objects.values('id', 'date', 'email').all()
+        bookings = Bookings.objects.values('id', 'date', 'email').all().order_by('-id')[:100]
         return render(request, 'bookings.html', {'bookings': bookings})
 
 @common_decorators(['GET'])

--- a/app/parking/views.py
+++ b/app/parking/views.py
@@ -230,7 +230,7 @@ def bookings(request):
         for bay in request.data['bays']:
 
             try:
-              CarBay.objects.get(pk=bay['bay'])
+                CarBay.objects.get(pk=bay['bay'])
             except CarBay.DoesNotExist:
                 return JsonResponse({
                     'error': 'No Carpark bay could be found given the id.'

--- a/app/parking/views.py
+++ b/app/parking/views.py
@@ -228,6 +228,14 @@ def bookings(request):
 
         # Save Bays
         for bay in request.data['bays']:
+
+            try:
+              CarBay.objects.get(pk=bay['bay'])
+            except CarBay.DoesNotExist:
+                return JsonResponse({
+                    'error': 'No Carpark bay could be found given the id.'
+                }, status=status.HTTP_400_BAD_REQUEST)
+
             bayBooked = bay
             bayBooked['booking_id'] = bookingsSerializer.data['pk']
             bayBooked['bay_id'] = bay['bay']

--- a/app/resources/templates/booking.html
+++ b/app/resources/templates/booking.html
@@ -32,8 +32,8 @@
           <div class="table-row-actions" data-light="{% if forloop.counter|divisibleby:2 == 0 %}true{% else %}false{% endif %}">
             <div class="table-row">
               <h4 data-thin="true">{{bay.bay.bay_number}}</h4>
-              <h4 data-thin="true">{{bay.start_time}}</h4>
-              <h4 data-thin="true">{{bay.end_time}}</h4>
+              <h4 data-thin="true">{{bay.start_time|date:"fa"}}</h4>
+              <h4 data-thin="true">{{bay.end_time|date:"fa"}}</h4>
             </div>
             <div class="table-actions"></div>
           </div>

--- a/app/resources/templates/booking.html
+++ b/app/resources/templates/booking.html
@@ -32,8 +32,8 @@
           <div class="table-row-actions" data-light="{% if forloop.counter|divisibleby:2 == 0 %}true{% else %}false{% endif %}">
             <div class="table-row">
               <h4 data-thin="true">{{bay.bay.bay_number}}</h4>
-              <h4 data-thin="true">{{bay.start_time|date:"fa"}}</h4>
-              <h4 data-thin="true">{{bay.end_time|date:"fa"}}</h4>
+              <h4 data-thin="true">{{bay.start_time|date:"f a"}}</h4>
+              <h4 data-thin="true">{{bay.end_time|date:"f a"}}</h4>
             </div>
             <div class="table-actions"></div>
           </div>

--- a/frontend/components/BookingForm/Booking.integration.test.tsx
+++ b/frontend/components/BookingForm/Booking.integration.test.tsx
@@ -30,7 +30,7 @@ const renderToStep2 = async (fetch = true) => {
     fetchMock.mockResponseOnce(JSON.stringify(carparks));
     fetchMock.mockResponseOnce(JSON.stringify(bays));
     fetchMock.mockResponseOnce(JSON.stringify({ success: true, bays: baysBooked }));
-    fetchMock.mockResponseOnce(JSON.stringify({ success: true }));
+    fetchMock.mockResponseOnce(JSON.stringify({ success: true, booking_id: 1 }));
   }
 
   const component = render(<BookingForm {...initialProps} />);
@@ -221,6 +221,19 @@ describe('Booking Form Step 2', () => {
     await waitFor(() => expect(getByText(/Something went wrong when fetching bays for carpark/)).toBeInTheDocument());
   });
 
+  it('bay additional info works correctly', async () => {
+    const { getByText, getAllByTestId } = await renderToStep2();
+    UserEvent.click(getAllByTestId('additionalInfo')[0]);
+    UserEvent.click(getByText('Close'));
+  });
+
+  it('click on unavailable time slot should do nothing', async () => {
+    const { container } = await renderToStep2();
+    const allNodes = container.querySelectorAll('[data-unavailable="true"]');
+    UserEvent.click(allNodes[0]);
+    expect(container.querySelectorAll('[data-unavailable="true"]').length).toBe(allNodes.length);
+  });
+
   it('completes step 2 correctly', async () => {
     const { getByText, getAllByTestId } = await renderToStep2();
     expect(getByText(/Select bay for/)).toBeInTheDocument();
@@ -326,5 +339,15 @@ describe('Booking Form Confirmation', () => {
   it('return button works correctly', async () => {
     const { getByText } = await renderToConfirmation();
     UserEvent.click(getByText('Return'));
+  });
+
+  it('pdf buttons works correctly', async () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore next
+    delete window.open;
+    window.open = jest.fn();
+    const { getByText } = await renderToConfirmation();
+    UserEvent.click(getByText('Download PDF'));
+    expect(window.open).toHaveBeenCalledWith('/admin/bookings/download/1', '_blank', 'noopener,noreferrer');
   });
 });

--- a/frontend/components/BookingForm/__snapshots__/Booking.integration.test.tsx.snap
+++ b/frontend/components/BookingForm/__snapshots__/Booking.integration.test.tsx.snap
@@ -984,11 +984,6 @@ exports[`Booking Form Step 2 matches its snapshot 1`] = `
               >
                 23:30
               </p>
-              <p
-                data-small-bold="true"
-              >
-                24:00
-              </p>
             </div>
           </div>
           <div
@@ -1006,6 +1001,7 @@ exports[`Booking Form Step 2 matches its snapshot 1`] = `
                 </p>
                 <button
                   class="additionInfo"
+                  data-testid="additionalInfo"
                   type="button"
                 >
                   <svg
@@ -1205,7 +1201,7 @@ exports[`Booking Form Step 2 matches its snapshot 1`] = `
                   class="bayTime"
                   data-selected="false"
                   data-testid="bay-time"
-                  data-unavailable="true"
+                  data-unavailable="false"
                   type="button"
                 />
                 <button
@@ -1247,21 +1243,14 @@ exports[`Booking Form Step 2 matches its snapshot 1`] = `
                   class="bayTime"
                   data-selected="false"
                   data-testid="bay-time"
-                  data-unavailable="true"
+                  data-unavailable="false"
                   type="button"
                 />
                 <button
                   class="bayTime"
                   data-selected="false"
                   data-testid="bay-time"
-                  data-unavailable="true"
-                  type="button"
-                />
-                <button
-                  class="bayTime"
-                  data-selected="false"
-                  data-testid="bay-time"
-                  data-unavailable="true"
+                  data-unavailable="false"
                   type="button"
                 />
                 <button
@@ -1383,6 +1372,7 @@ exports[`Booking Form Step 2 matches its snapshot 1`] = `
                 </p>
                 <button
                   class="additionInfo"
+                  data-testid="additionalInfo"
                   type="button"
                 >
                   <svg
@@ -1590,6 +1580,370 @@ exports[`Booking Form Step 2 matches its snapshot 1`] = `
                   data-selected="false"
                   data-testid="bay-time"
                   data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="true"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="true"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="true"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="true"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="true"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="true"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="true"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="true"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+              </div>
+            </div>
+            <div
+              class="bay"
+              data-light="false"
+            >
+              <div
+                class="left"
+              >
+                <p>
+                  9233
+                </p>
+                <button
+                  class="additionInfo"
+                  data-testid="additionalInfo"
+                  type="button"
+                >
+                  <svg
+                    fill="none"
+                    height="24"
+                    id="info"
+                    viewBox="0 0 24 24"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+                      fill="#323232"
+                    />
+                  </svg>
+                </button>
+              </div>
+              <div
+                class="bayTimes"
+              >
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="false"
+                  type="button"
+                />
+                <button
+                  class="bayTime"
+                  data-selected="false"
+                  data-testid="bay-time"
+                  data-unavailable="true"
                   type="button"
                 />
                 <button
@@ -1750,16 +2104,17 @@ exports[`Booking Form Step 2 matches its snapshot 1`] = `
             </div>
             <div
               class="bay"
-              data-light="false"
+              data-light="true"
             >
               <div
                 class="left"
               >
                 <p>
-                  9233
+                  66974
                 </p>
                 <button
                   class="additionInfo"
+                  data-testid="additionalInfo"
                   type="button"
                 >
                   <svg
@@ -1780,13 +2135,6 @@ exports[`Booking Form Step 2 matches its snapshot 1`] = `
               <div
                 class="bayTimes"
               >
-                <button
-                  class="bayTime"
-                  data-selected="false"
-                  data-testid="bay-time"
-                  data-unavailable="false"
-                  type="button"
-                />
                 <button
                   class="bayTime"
                   data-selected="false"

--- a/frontend/components/BookingForm/index.tsx
+++ b/frontend/components/BookingForm/index.tsx
@@ -61,6 +61,7 @@ const BookingForm = ({ globalStartTime, globalEndTime, phone, userId, hub }: Pro
   const ActivePage = useMemo(() => Steps[step], [step]);
   const next = () => setStep(Math.min(step + 1, Steps.length - 1));
   const back = () => setStep(Math.max(step - 1, 0));
+  const closeModal = () => setShowHelp(false);
 
   const finalSubmit = async (values: BookingFormValues) => {
     setLoading(true);
@@ -78,7 +79,7 @@ const BookingForm = ({ globalStartTime, globalEndTime, phone, userId, hub }: Pro
       bays: createListItems(values.booking).map((b) => ({
         bay: b[0]?.bayId,
         start_time: b[0]?.time,
-        end_time: b[1]?.time || b[0]?.time,
+        end_time: b[1]?.endTime || b[0]?.endTime,
       })),
     };
 
@@ -198,14 +199,14 @@ const BookingForm = ({ globalStartTime, globalEndTime, phone, userId, hub }: Pro
       <ReactModal
         isOpen={showHelp}
         shouldCloseOnEsc={true}
-        onRequestClose={() => setShowHelp(false)}
+        onRequestClose={closeModal}
         shouldCloseOnOverlayClick={true}
         className={styles.modal}
         ariaHideApp={false}
       >
         {documentation[step]}
         <div className={styles.closeButton}>
-          <CustomButton onClick={() => setShowHelp(false)} type={ButtonType.button} icon={undefined}>
+          <CustomButton onClick={closeModal} type={ButtonType.button} icon={undefined}>
             Close
           </CustomButton>
         </div>

--- a/frontend/components/BookingForm/steps/BaySelection/index.tsx
+++ b/frontend/components/BookingForm/steps/BaySelection/index.tsx
@@ -21,6 +21,7 @@ const BaySelection: StepComponent = () => {
   const [props, setProps] = useState<BaysInitialProps>();
   const [modalDesc, setModalDesc] = useState<string | undefined>(undefined);
 
+  const closeModal = () => setModalDesc(undefined);
   const getBays = useCallback(async () => {
     return await fetch(`/api/carparks/${values.carpark!.pk}/bays`).then((r) => r.json());
   }, [values.carpark]);
@@ -176,7 +177,12 @@ const BaySelection: StepComponent = () => {
                 <div className={styles.left}>
                   <p>{bay.bayNum}</p>
                   {bay.desc && (
-                    <button type="button" className={styles.additionInfo} onClick={() => setModalDesc(bay.desc)}>
+                    <button
+                      type="button"
+                      data-testid="additionalInfo"
+                      className={styles.additionInfo}
+                      onClick={() => setModalDesc(bay.desc)}
+                    >
                       <InfoIcon />
                     </button>
                   )}
@@ -206,14 +212,14 @@ const BaySelection: StepComponent = () => {
       <ReactModal
         isOpen={!!modalDesc}
         shouldCloseOnEsc={true}
-        onRequestClose={() => setModalDesc(undefined)}
+        onRequestClose={closeModal}
         shouldCloseOnOverlayClick={true}
         className={styles.modal}
         ariaHideApp={false}
       >
         {modalDesc}
         <div className={styles.closeButton}>
-          <CustomButton onClick={() => setModalDesc(undefined)} type={ButtonType.button} icon={undefined}>
+          <CustomButton onClick={closeModal} type={ButtonType.button} icon={undefined}>
             Close
           </CustomButton>
         </div>

--- a/frontend/lib/BayInitialProps.ts
+++ b/frontend/lib/BayInitialProps.ts
@@ -1,4 +1,4 @@
-import Times from './Times';
+import Times, { standardTime } from './Times';
 
 const AVAILABLE = 0;
 const SELECTED = 1;
@@ -6,39 +6,58 @@ const UNAVAILABLE = 2;
 
 const selection = { AVAILABLE, SELECTED, UNAVAILABLE };
 
+/**
+ * Gets all times slots based on a start time and end time with 30mins interval
+ * @param globalStartTime global start time of booking system
+ * @param globalEndTime global end time of booking system
+ * @throws Error if global start time and end time are equal and not 00:00, as that represents a day
+ * @returns All time slots available for the day
+ */
+const getTimes = (globalStartTime: string, globalEndTime: string): string[] => {
+  if (globalStartTime === '00:00' && globalEndTime === '00:00') return Times;
+  if (globalStartTime === globalEndTime) throw new Error('Global start time and global end time cannot be equal');
+
+  const times: string[] = [];
+  let foundStart = false;
+  for (let i = 0; i < Times.length; i++) {
+    if (Times[i] === globalStartTime) foundStart = true;
+    if (foundStart) {
+      if (Times[i] === globalEndTime) break;
+      times.push(Times[i]);
+    }
+  }
+
+  return times;
+};
+
+/**
+ * Gets the initial state of all bays and their status (AVAILABLE or UNAVAILABLE)
+ * @param bayResponse all bays from the api
+ * @param bookedBaysResponse all booked bays and there times from the api
+ * @param globalStartTime global start time of booking system
+ * @param globalEndTime global end time of booking system
+ * @returns times available, bays and information about their times
+ */
 const getInitialState = (
   bayResponse: BayResponse[],
   bookedBaysResponse: BaysBookedResponse,
   globalStartTime: string,
   globalEndTime: string,
 ): BaysInitialProps => {
-  const times: string[] = [];
-  let foundStart = false;
-  let translation = 0;
-  for (let i = 0; i < Times.length; i++) {
-    if (Times[i] == globalStartTime) {
-      translation = i;
-      foundStart = true;
-    }
-    if (foundStart) {
-      times.push(Times[i]);
-      // need foundStart to be true if for example 12:00 A.M. is the end time
-      if (Times[i] == globalEndTime) break;
-    }
-  }
-
-  const ppBaysBooked = ProcessBaysBooked(bookedBaysResponse.bays, times);
-  const bays: Bay[] = bayResponse.map((b, i) => ({
+  const times = getTimes(globalStartTime, globalEndTime);
+  const ppBaysBooked = processBaysBooked(bookedBaysResponse.bays, times);
+  const bays: Bay[] = bayResponse.map((b, row) => ({
     bayId: b.pk,
     bayNum: parseInt(b.bay_number),
     desc: b.description,
-    times: [...new Array(times.length)].map((_, j) => ({
-      slug: `bay:${i + 1}-time:${times[j]}`,
-      status: ppBaysBooked[b.pk]?.[times[j]] ? UNAVAILABLE : AVAILABLE,
-      bayId: b.pk,
-      bayNum: parseInt(b.bay_number),
-      time: times[j],
-      index: j + translation,
+    times: [...new Array(times.length)].map((_, i) => ({
+      slug: `bay:${row + 1}-time:${times[i]}`, // Our own key value, used to store in map
+      status: ppBaysBooked[b.pk]?.[times[i]] ? UNAVAILABLE : AVAILABLE,
+      bayId: b.pk, // Bay id is the id of bay set in db
+      bayNum: parseInt(b.bay_number), // Bay number is set by unipark staff
+      time: times[i],
+      index: i,
+      endTime: Times[(Times.indexOf(times[i]) + 1) % Times.length],
     })),
   }));
 
@@ -46,17 +65,24 @@ const getInitialState = (
 };
 
 interface PreprocessedTimes {
-  [bay: string]: {
+  [id: number]: {
     [time: string]: boolean;
   };
 }
 
-const ProcessBaysBooked = (bookedBaysResponse: BaysBookedResponse['bays'], times: string[]): PreprocessedTimes => {
+/**
+ * Processes bays booked api response into an object
+ * so we know which time slots have been taken up
+ * @param bookedBaysResponse all booked bays and there times from the api
+ * @param times times that are available to use
+ * @returns process time slots that have been taken up
+ */
+const processBaysBooked = (bookedBaysResponse: BaysBookedResponse['bays'], times: string[]): PreprocessedTimes => {
   const baysBooked: PreprocessedTimes = {};
   bookedBaysResponse.forEach((b) => {
     let foundStart = false;
-    const START_TIME = b.start_time.slice(0, -3);
-    const END_TIME = b.end_time.slice(0, -3);
+    const START_TIME = standardTime(b.start_time);
+    const END_TIME = standardTime(b.end_time);
     for (let i = 0; i < times.length; i++) {
       if (times[i] === START_TIME) foundStart = true;
       if (foundStart) {
@@ -67,11 +93,11 @@ const ProcessBaysBooked = (bookedBaysResponse: BaysBookedResponse['bays'], times
           baysBooked[b.bay.id][times[i]] = true;
         }
       }
-      if (times[i] === END_TIME) break;
+      if (times[i + 1] === END_TIME) break;
     }
   });
 
   return baysBooked;
 };
 
-export { getInitialState, selection };
+export { getInitialState, selection, getTimes, processBaysBooked };

--- a/frontend/lib/BayInitialProps.ts
+++ b/frontend/lib/BayInitialProps.ts
@@ -46,6 +46,7 @@ const getInitialState = (
 ): BaysInitialProps => {
   const times = getTimes(globalStartTime, globalEndTime);
   const ppBaysBooked = processBaysBooked(bookedBaysResponse.bays, times);
+  const offset = Times.indexOf(globalStartTime) + 1;
   const bays: Bay[] = bayResponse.map((b, row) => ({
     bayId: b.pk,
     bayNum: parseInt(b.bay_number),
@@ -57,7 +58,7 @@ const getInitialState = (
       bayNum: parseInt(b.bay_number), // Bay number is set by unipark staff
       time: times[i],
       index: i,
-      endTime: Times[(Times.indexOf(times[i]) + 1) % Times.length],
+      endTime: Times[(offset + i) % Times.length],
     })),
   }));
 

--- a/frontend/lib/ProcessBayMap.tsx
+++ b/frontend/lib/ProcessBayMap.tsx
@@ -1,25 +1,24 @@
 import React from 'react';
-import timePeriods from '@/frontend/lib/Times';
 
 export default function createListItems(bayTimes: Map<string, Time>) {
   const timeSlugs = [...bayTimes.keys()];
+  // Sort by bayNum, then by time (index of that time slot)
   timeSlugs.sort((time1, time2) => {
-    const booking1 = bayTimes.get(time1);
-    const booking2 = bayTimes.get(time2);
-    const difference = booking1!.bayNum - booking2!.bayNum;
+    const booking1 = bayTimes.get(time1)!;
+    const booking2 = bayTimes.get(time2)!;
+    const difference = booking1.bayNum - booking2.bayNum;
 
-    if (difference == 0) {
-      return booking1!.index - booking2!.index;
-    } else return difference;
+    return difference == 0 ? booking1.index - booking2.index : difference;
   });
 
-  const cleanedTimes: (Time | undefined)[][] = [];
+  const cleanedTimes: Time[][] = [];
   let i = 0;
 
   while (i < timeSlugs.length) {
-    const consecutivePeriod: (Time | undefined)[] = [];
-    consecutivePeriod.push(bayTimes.get(timeSlugs[i]));
-    let j = i;
+    // We push the first bayNum on then loop through the same bayNum that proceed after
+    const consecutivePeriod: Time[] = [];
+    consecutivePeriod.push(bayTimes.get(timeSlugs[i])!);
+    let j = i; // j represents current bayNum we are looking at
 
     while (j < timeSlugs.length - 1) {
       const current = bayTimes.get(timeSlugs[j]);
@@ -33,7 +32,7 @@ export default function createListItems(bayTimes: Map<string, Time>) {
       else break;
     }
 
-    if (j != i) consecutivePeriod.push(bayTimes.get(timeSlugs[j]));
+    if (j != i) consecutivePeriod.push(bayTimes.get(timeSlugs[j])!);
     i = j + 1;
     cleanedTimes.push(consecutivePeriod);
   }
@@ -44,17 +43,17 @@ export default function createListItems(bayTimes: Map<string, Time>) {
 export function renderCleanedTimes(bayTimes: Map<string, Time>) {
   const listItems = createListItems(bayTimes).map((bookedTime) => {
     return bookedTime.length == 1 ? (
-      <tr key={bookedTime[0]?.slug}>
-        <td>{bookedTime[0]!.bayNum}</td>
+      <tr key={bookedTime[0].slug}>
+        <td>{bookedTime[0].bayNum}</td>
         <td>
-          {bookedTime[0]!.time}-{timePeriods[bookedTime[0]!.index + 1]}
+          {bookedTime[0].time}-{bookedTime[0].endTime}
         </td>
       </tr>
     ) : (
-      <tr key={bookedTime[0]?.slug}>
-        <td>{bookedTime[0]!.bayNum} </td>
+      <tr key={bookedTime[0].slug}>
+        <td>{bookedTime[0].bayNum} </td>
         <td>
-          {bookedTime[0]!.time}-{timePeriods[bookedTime[1]!.index + 1]}
+          {bookedTime[0].time}-{bookedTime[1].endTime}
         </td>
       </tr>
     );

--- a/frontend/lib/Times.ts
+++ b/frontend/lib/Times.ts
@@ -1,3 +1,13 @@
+/**
+ * Standardise time *just in case*
+ * We take HH:MM always
+ * E.g., HH:MM:SS or any other
+ * @param time time to standardise
+ */
+export function standardTime(time: string): string {
+  return time.split(':').slice(0, 2).join(':');
+}
+
 export default [
   '00:00',
   '00:30',
@@ -47,5 +57,4 @@ export default [
   '22:30',
   '23:00',
   '23:30',
-  '24:00',
 ];

--- a/frontend/lib/tests/BayInitialProps.unit.test.ts
+++ b/frontend/lib/tests/BayInitialProps.unit.test.ts
@@ -1,0 +1,114 @@
+import { bayBooked, baysBooked } from '@/frontend/tests/mocks/baysBooked';
+import { bays } from '@/frontend/tests/mocks/bays';
+import { uniq } from 'lodash';
+
+import Times, { standardTime } from '../Times';
+import { getInitialState, getTimes, processBaysBooked, selection } from '../BayInitialProps';
+
+describe('getTimes()', () => {
+  it('start=00:00, end=00:00 returns all times', () => {
+    const times = getTimes('00:00', '00:00');
+    expect(times).toEqual(Times);
+  });
+
+  it('start=08:00, end=10:00', () => {
+    const times = getTimes('08:00', '10:00');
+    expect(times).toEqual(['08:00', '08:30', '09:00', '09:30']);
+  });
+
+  it('start=08:00, end=08:00 throws error', () => {
+    expect(() => getTimes('08:00', '08:00')).toThrow('Global start time and global end time cannot be equal');
+  });
+});
+
+describe('processBaysBooked()', () => {
+  const processBooking = processBaysBooked(baysBooked, getTimes('00:00', '00:00'));
+  it('All bay ids appear in processed bookings', () => {
+    // When processing bookings, we create a object/map with index being id
+    // All bay ids fetched from the api should appear in the processed booking result
+
+    // we toString() as `obj[1] = true;` becomes `{'1': true};` which is done in processBaysBooked()
+    const allBayIds = baysBooked.map((b) => b.bay.id.toString());
+    expect(uniq(allBayIds)).toEqual(Object.keys(processBooking));
+  });
+
+  it('End times should not appear in processed bookings, instead corresponding slot', () => {
+    // Corresponding slots should show. E.g., end_time = 10:00, that corresponding booking slot is 09:30
+    const endTimes: { [id: number]: string[] } = {};
+    baysBooked.forEach((b) => {
+      endTimes[b.bay.id] = [...(endTimes?.[b.bay.id] || []), standardTime(b.end_time)]; // slice to get rid of :SS from HH:MM:SS
+    });
+    Object.keys(endTimes).forEach((id) => {
+      expect(Object.keys(processBooking[id]).some((time) => endTimes[id].includes(time))).toBe(false);
+    });
+  });
+
+  it('All start times should appear in process bookings in their corresponding bay', () => {
+    const startTimes: { [id: number]: string[] } = {};
+    baysBooked.forEach((b) => {
+      startTimes[b.bay.id] = [...(startTimes?.[b.bay.id] || []), standardTime(b.start_time)];
+    });
+    Object.keys(startTimes).forEach((id) => {
+      expect(Object.keys(processBooking[id]).some((time) => startTimes[id].includes(time))).toBe(true);
+    });
+  });
+
+  it('bookings made on the edges works correctly', () => {
+    const edgeBookings = [bayBooked(1, '00:00:00', '01:00:00'), bayBooked(1, '23:00:00', '00:00:00')];
+    const processEdge = processBaysBooked(edgeBookings, getTimes('00:00', '00:00'));
+    const timesThatShouldExist = ['00:00', '00:30', '23:00', '23:30'];
+    expect(Object.keys(processEdge['1']).sort()).toEqual(timesThatShouldExist);
+  });
+
+  it('*somehow* if bays booked times overlap, a reasonable processing should occur', () => {
+    const overlappedBooking = [bayBooked(1, '02:00:00', '03:00:00'), bayBooked(1, '01:00:00', '02:30:00')];
+    const processOverlapped = processBaysBooked(overlappedBooking, getTimes('00:00', '00:00'));
+    const timesThatShouldExist = ['01:00', '01:30', '02:00', '02:30'];
+    expect(Object.keys(processOverlapped['1']).sort()).toEqual(timesThatShouldExist);
+  });
+});
+
+describe('getInitialState()', () => {
+  it('returns correct information given mock', () => {
+    const state = getInitialState(bays, { success: true, bays: baysBooked }, '00:00', '00:00');
+    expect(state.times).toEqual(Times);
+    state.bays.forEach((b) => {
+      expect(b.times.length).toBe(Times.length);
+    });
+    // Check slot 1
+    expect(state.bays[0].times[0].slug).toBe('bay:1-time:00:00');
+    expect(state.bays[0].times[0].status).toBe(selection.AVAILABLE);
+    expect(state.bays[0].times[0].endTime).toBe('00:30');
+
+    // Check last slot
+    expect(state.bays[0].times[state.times.length - 1].slug).toBe('bay:1-time:23:30');
+    expect(state.bays[0].times[0].status).toBe(selection.AVAILABLE);
+    expect(state.bays[0].times[state.times.length - 1].endTime).toBe('00:00');
+  });
+
+  it('bookings made on the edges', () => {
+    const state = getInitialState(
+      bays,
+      { success: true, bays: [bayBooked(1, '00:00:00', '01:00:00'), bayBooked(1, '23:00:00', '00:00:00')] },
+      '00:00',
+      '00:00',
+    );
+
+    expect(state.bays[0].times[0].slug).toBe('bay:1-time:00:00');
+    expect(state.bays[0].times[0].status).toBe(selection.UNAVAILABLE);
+    expect(state.bays[0].times[0].endTime).toBe('00:30');
+
+    expect(state.bays[0].times[state.times.length - 1].slug).toBe('bay:1-time:23:30');
+    expect(state.bays[0].times[0].status).toBe(selection.UNAVAILABLE);
+    expect(state.bays[0].times[state.times.length - 1].endTime).toBe('00:00');
+  });
+
+  it('normal start and end time', () => {
+    const state = getInitialState(bays, { success: true, bays: baysBooked }, '08:00', '20:00');
+
+    expect(state.bays[0].times[0].slug).toBe('bay:1-time:08:00');
+    expect(state.bays[0].times[0].endTime).toBe('08:30');
+    expect(state.bays[0].times[state.times.length - 1].slug).toBe('bay:1-time:19:30');
+    expect(state.bays[0].times[state.times.length - 1].endTime).toBe('20:00');
+  });
+});

--- a/frontend/lib/tests/ProcessBayMap.unit.test.tsx
+++ b/frontend/lib/tests/ProcessBayMap.unit.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { TimeMocks } from '@/frontend/tests/mocks/time';
+import { render } from '@testing-library/react';
+
+import createListItems, { renderCleanedTimes } from '../ProcessBayMap';
+
+const bayTimes = new Map();
+TimeMocks.forEach((t) => bayTimes.set(t.slug, t));
+
+describe('createListItems()', () => {
+  it('works correctly given mock', () => {
+    const listItems = createListItems(bayTimes);
+    expect(listItems[0].map((t) => t.time)).toEqual(['08:00', '09:00']);
+    expect(listItems[1].map((t) => t.time)).toEqual(['22:30', '23:30']);
+    expect(listItems[1][1].endTime).toBe('00:00');
+    expect(listItems[2].length).toBe(1);
+  });
+});
+
+describe('renderCleanedTimes()', () => {
+  it('matches its snapshot', () => {
+    const component = () => (
+      <table>
+        <tbody>{renderCleanedTimes(bayTimes)}</tbody>
+      </table>
+    );
+    expect(render(component()).baseElement).toMatchSnapshot();
+  });
+});

--- a/frontend/lib/tests/Times.unit.test.ts
+++ b/frontend/lib/tests/Times.unit.test.ts
@@ -1,0 +1,11 @@
+import { standardTime } from '../Times';
+
+describe('standardTime()', () => {
+  it('HH:MM returns HH:MM', () => {
+    expect(standardTime('00:00')).toBe('00:00');
+  });
+
+  it('HH:MM:SS returns HH:MM', () => {
+    expect(standardTime('00:00:00')).toBe('00:00');
+  });
+});

--- a/frontend/lib/tests/__snapshots__/ProcessBayMap.unit.test.tsx.snap
+++ b/frontend/lib/tests/__snapshots__/ProcessBayMap.unit.test.tsx.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renderCleanedTimes() matches its snapshot 1`] = `
+<body>
+  <div>
+    <table>
+      <tbody>
+        <tr>
+          <td>
+            1
+             
+          </td>
+          <td>
+            08:00
+            -
+            09:30
+          </td>
+        </tr>
+        <tr>
+          <td>
+            2
+             
+          </td>
+          <td>
+            22:30
+            -
+            00:00
+          </td>
+        </tr>
+        <tr>
+          <td>
+            3
+          </td>
+          <td>
+            00:00
+            -
+            00:30
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+`;

--- a/frontend/tests/mocks/bays.ts
+++ b/frontend/tests/mocks/bays.ts
@@ -9,6 +9,6 @@ const bay = (id: number): BayResponse => ({
   pk: id,
 });
 
-const bays = [bay(1), bay(2), bay(3)];
+const bays = [bay(1), bay(2), bay(3), bay(4)];
 
 export { bay, bays };

--- a/frontend/tests/mocks/baysBooked.ts
+++ b/frontend/tests/mocks/baysBooked.ts
@@ -16,8 +16,9 @@ const bayBooked = (id: number, start_time: string, end_time: string): BaysBooked
 
 const baysBooked = [
   bayBooked(1, '13:00:00', '15:30:00'),
-  bayBooked(1, '12:30:00', '12:30:00'),
-  bayBooked(1, '14:30:00', '18:30:00'),
+  bayBooked(1, '16:30:00', '18:30:00'),
+  bayBooked(2, '14:30:00', '18:30:00'),
+  bayBooked(3, '12:30:00', '13:00:00'),
 ];
 
 export { baysBooked, bayBooked };

--- a/frontend/tests/mocks/time.ts
+++ b/frontend/tests/mocks/time.ts
@@ -1,0 +1,28 @@
+import faker from 'faker';
+
+import Times from '../../lib/Times';
+import { selection } from '../../lib/BayInitialProps';
+
+faker.seed(1);
+
+const TimeMock = (bayNum: number, time: string): Time => ({
+  time: time,
+  slug: `bay:${bayNum}-time:${time}`,
+  status: selection.AVAILABLE,
+  bayNum: bayNum,
+  bayId: faker.datatype.number(),
+  index: Times.indexOf(time),
+  endTime: Times[(Times.indexOf(time) + 1) % Times.length],
+});
+
+const TimeMocks = [
+  TimeMock(1, '08:00'),
+  TimeMock(1, '08:30'),
+  TimeMock(1, '09:00'),
+  TimeMock(2, '22:30'),
+  TimeMock(2, '23:00'),
+  TimeMock(2, '23:30'),
+  TimeMock(3, '00:00'),
+];
+
+export { TimeMock, TimeMocks };

--- a/frontend/typings/Booking.d.ts
+++ b/frontend/typings/Booking.d.ts
@@ -57,6 +57,7 @@ interface Time {
   bayNum: number;
   index: number;
   bayId: number;
+  endTime: string;
 }
 
 interface BaysInitialProps {


### PR DESCRIPTION
The booking system is 100% tested now and should work as intended. The only issues I can see are edge cases that I haven't tested for. Other than that its 100% coverage

Moving onto buffer system tonight. I just had to make sure the current system as we have works 100%, before adding buffers

- 100% coverage
- limited booking view to 100 bookings, and the top one is the most recent booking
- fixed date on booking, so it doesn't show `noon` or `midnight` anymore
- added test cases for booking
- add `standardTime` to convert the different formats just in case (e.g., HH:MM:SS and HH:MM)
- added try and except to `api/bookings` POST if carbay is not found